### PR TITLE
Nonprofit link added into navbar

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ More details can be found at this project's [code of conduct](.github/CODE_OF_CO
 - [Sonali Agrawal](https://github.com/sonali9696)
 - [Kristal Garcia](https://github.com/kgmajor)
 - [Enrique Novoa](https://github.com/enriquenov)
+- [Terrence Eisenhower](https://github.com/teisenhower)
 
 ### Thank you to **all our backers**! ([Become a backer](https://opencollective.com/techqueria#backer))
 

--- a/config.toml
+++ b/config.toml
@@ -243,6 +243,9 @@ disqusShortname                      = "techqueria"
     parent                           = "Resources"
     name                             = "Nonprofits 💛"
     url                              = "/resources/nonprofits/"
+[[menu.main]]
+    name                             = "Nonprofits"
+    url                              = "/resources/nonprofits/"
 
 #
 # Supporting Multiple Languages


### PR DESCRIPTION
Added new link item in navbar for **Nonprofits page**
- Fixes #330        
````toml
[[menu.main]]
    name                             = "Nonprofits"
    url                              = "/resources/nonprofits/"
````

---

<!-- Thank you for contributing to Techqueria, it is much appreciated! 😊 -->

<!-- Before creating a PR, make sure to verify the following. -->

> ✅️ By submitting this PR, I have verified the following

- [x] Checked to [see if a similar PR has already been opened](https://github.com/techqueria/website/pulls) 🤔️
- [x] Reviewed the [contributing guidelines](https://github.com/techqueria/website/blob/master/.github/CONTRIBUTING.md) 🔍️
- [x] Added my name to the bottom of the list under the **Contributors** section in the [README.md](https://github.com/techqueria/website/blob/master/README.md) with a link to my personal website or GitHub profile 👥️
