### PR TITLE
Add automatic contributor invites to issue/PR comments

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -49,9 +49,14 @@ sentimentBotReplyComment: >
 newIssueWelcomeComment: >
   Thank you for raising an issue! 🌮
 
+
   Please make sure you have given us enough context and we will review it as soon as possible. ⏲️
 
+
   If you don't hear back from anyone within the next week, feel free to reach out to one of the maintainers. 💛
+  
+  
+  And if you haven't already, become an official contributor using [this link](http://probot-invite.herokuapp.com/join/eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0ZWNocXVlcmlhIiwiaXNzIjo4NDg3MTQsInJvbGUiOiJtZW1iZXIiLCJ0ZWFtcyI6WyIyMTQ0NDU0Il0sImlhdCI6MTU1NTU0NDI3OX0.UfCj5CdniOAPtFFy5ZOpCcVFzFbXDcmEqTK_y__nmiA). This will allow you to showcase the Techqueria GitHub organization on your profile! 😸
 
 # Configuration for new-pr-welcome - https://github.com/behaviorbot/new-pr-welcome
 # Comment to be posted to on PRs from first time contributors in your repository
@@ -59,9 +64,14 @@ newIssueWelcomeComment: >
 newPRWelcomeComment: >
   Thanks for opening this pull request! 🌮
 
+
   Please make sure you have followed our contributing guidelines and we will review it as soon as possible. ⏲️
 
+
   If you don't hear back from anyone within the next week, feel free to reach out to one of the maintainers. 💛
+  
+  
+  And if you haven't already, become an official contributor using [this link](http://probot-invite.herokuapp.com/join/eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0ZWNocXVlcmlhIiwiaXNzIjo4NDg3MTQsInJvbGUiOiJtZW1iZXIiLCJ0ZWFtcyI6WyIyMTQ0NDU0Il0sImlhdCI6MTU1NTU0NDI3OX0.UfCj5CdniOAPtFFy5ZOpCcVFzFbXDcmEqTK_y__nmiA). This will allow you to showcase the Techqueria GitHub organization on your profile! 😸
 
 # Configuration for first-pr-merge - https://github.com/behaviorbot/first-pr-merge
 # Comment to be posted to on pull requests merged by a first time user

--- a/.github/config.yml
+++ b/.github/config.yml
@@ -56,7 +56,7 @@ newIssueWelcomeComment: >
   If you don't hear back from anyone within the next week, feel free to reach out to one of the maintainers. 💛
   
   
-  And if you haven't already, become an official contributor using [this link](http://probot-invite.herokuapp.com/join/eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0ZWNocXVlcmlhIiwiaXNzIjo4NDg3MTQsInJvbGUiOiJtZW1iZXIiLCJ0ZWFtcyI6WyIyMTQ0NDU0Il0sImlhdCI6MTU1NTU0NDI3OX0.UfCj5CdniOAPtFFy5ZOpCcVFzFbXDcmEqTK_y__nmiA). This will allow you to showcase the Techqueria GitHub organization on your profile! 😸
+  And if you haven't already, become an official contributor using [this link](https://bit.ly/become-a-techqueria-github-contributor). This will allow you to showcase the Techqueria GitHub organization on your profile! 😸
 
 # Configuration for new-pr-welcome - https://github.com/behaviorbot/new-pr-welcome
 # Comment to be posted to on PRs from first time contributors in your repository
@@ -71,7 +71,7 @@ newPRWelcomeComment: >
   If you don't hear back from anyone within the next week, feel free to reach out to one of the maintainers. 💛
   
   
-  And if you haven't already, become an official contributor using [this link](http://probot-invite.herokuapp.com/join/eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0ZWNocXVlcmlhIiwiaXNzIjo4NDg3MTQsInJvbGUiOiJtZW1iZXIiLCJ0ZWFtcyI6WyIyMTQ0NDU0Il0sImlhdCI6MTU1NTU0NDI3OX0.UfCj5CdniOAPtFFy5ZOpCcVFzFbXDcmEqTK_y__nmiA). This will allow you to showcase the Techqueria GitHub organization on your profile! 😸
+  And if you haven't already, become an official contributor using [this link](https://bit.ly/become-a-techqueria-github-contributor). This will allow you to showcase the Techqueria GitHub organization on your profile! 😸
 
 # Configuration for first-pr-merge - https://github.com/behaviorbot/first-pr-merge
 # Comment to be posted to on pull requests merged by a first time user


### PR DESCRIPTION
Using Probot to automatically create link so someone can become a contributor.

Link is added to new issues/PRs.

---

<!-- Thank you for contributing to Techqueria, it is much appreciated! 😊 -->

<!-- Before creating a PR, make sure to verify the following. -->

> ✅️ By submitting this PR, I have verified the following

- [x] Checked to [see if a similar PR has already been opened](https://github.com/techqueria/website/pulls) 🤔️
- [x] Reviewed the [contributing guidelines](https://github.com/techqueria/website/blob/master/.github/CONTRIBUTING.md) 🔍️
- [x] Added my name to the bottom of the list under the **Contributors** section in the [README.md](https://github.com/techqueria/website/blob/master/README.md) with a link to my personal website or GitHub profile 👥️
