### PR TITLE
Translate support us pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ More details can be found at this project's [code of conduct](.github/CODE_OF_CO
 - [Terrence Eisenhower](https://github.com/teisenhower)
 - [Bethany Meier](https://github.com/whimsicurl-creations)
 - [Juan Soto](http://www.jstechstack.com/)
+- [Omar De Los Santos](https://github.com/omarnyte)
 
 ### Thank you to **all our backers**! ([Become a backer](https://opencollective.com/techqueria#backer))
 

--- a/config.toml
+++ b/config.toml
@@ -557,15 +557,15 @@ disqusShortname                      = "techqueria"
 [[languages.es.menu.main]]
     parent                           = "Apoyanos"
     name                             = "Hazte voluntario"
-    url                              = "/volunteer/"
+    url                              = "/support-us/volunteer/"
 [[languages.es.menu.main]]
     parent                           = "Apoyanos"
     name                             = "Donar espacio"
-    url                              = "/donate-space/"
+    url                              = "/support-us/donate-space/"
 [[languages.es.menu.main]]
     parent                           = "Apoyanos"
     name                             = "Nuestros partidarios"
-    url                              = "/supporters/"
+    url                              = "/support-us/supporters/"
 
 [[languages.es.menu.social]]
     name                             = "LinkedIn"

--- a/content/support-us/_index.es.md
+++ b/content/support-us/_index.es.md
@@ -5,14 +5,14 @@ categories:
   - sitemap
 ---
 
-Help us grow one of the largest Latinx in Tech communities by becoming a sponsor, partner or volunteer.
+Ayúdenos a crecer una de las comunidades Latinx en Tech más grandes haciéndose un patrocinador, socio, o voluntario.
 
-> If you're interested in becoming an official sponsor or partner, please fill out the form below and we'll get back to you ASAP.
+> Si esta interesado en convertirse en un patrocinador o socio oficial, por favor complete el formulario y le contestaremos lo más pronto posible. 
 
 <form name="Become a Supporter" method="POST" data-netlify="true">
   <input type="hidden" aria-label="Subject" name="_subject" value="Techqueria - Become a Supporter">
   <div class="field">
-    <label class="label">Organization*</label>
+    <label class="label">Organización*</label>
     <div class="control has-icons-left">
       <input class="input" aria-label="Organization" autocomplete="on" type="text" name="organization" placeholder="Your organization" required>
       <span class="icon is-left">
@@ -21,7 +21,7 @@ Help us grow one of the largest Latinx in Tech communities by becoming a sponsor
     </div>
   </div>
   <div class="field">
-    <label class="label">Name*</label>
+    <label class="label">Nombre*</label>
     <div class="control has-icons-left">
       <input class="input" aria-label="Name" autocomplete="on" type="text" name="name" placeholder="Your name" required>
       <span class="icon is-left">
@@ -30,7 +30,7 @@ Help us grow one of the largest Latinx in Tech communities by becoming a sponsor
     </div>
   </div>
   <div class="field">
-    <label class="label">Email*</label>
+    <label class="label">Correo Electrónico*</label>
     <div class="control has-icons-left">
       <input class="input" aria-label="Email" autocomplete="on" type="email" name="email" placeholder="Your email" required>
       <span class="icon is-left">
@@ -39,7 +39,7 @@ Help us grow one of the largest Latinx in Tech communities by becoming a sponsor
     </div>
   </div>
   <div class="field">
-    <label class="label">LinkedIn Profile URL*</label>
+    <label class="label">URL de Perfil LinkedIn *</label>
     <div class="control has-icons-left">
       <input class="input" aria-label="Organization" autocomplete="on" type="url" name="organization" placeholder="https://www.linkedin.com/in/" required>
       <span class="icon is-left">
@@ -48,7 +48,7 @@ Help us grow one of the largest Latinx in Tech communities by becoming a sponsor
     </div>
   </div>
   <div class="field">
-    <label class="label">What does your maximum budget look like for sponsorship?</label>
+    <label class="label">¿Cuál parece ser su presupuesto máximo de patrocinio?</label>
     <div class="control has-icons-left">
       <input class="input" aria-label="Referral" type="number" name="referral" min="100" step="100" placeholder="">
       <span class="icon is-left">
@@ -57,7 +57,7 @@ Help us grow one of the largest Latinx in Tech communities by becoming a sponsor
     </div>
   </div>
   <div class="field">
-    <label class="label">How did you hear about Techqueria?</label>
+    <label class="label">¿Cómo escucho de Techqueria?</label>
     <div class="control has-icons-left">
       <input class="input" aria-label="Referral" autocomplete="on" type="text" name="referral" placeholder="Twitter">
       <span class="icon is-left">
@@ -66,7 +66,7 @@ Help us grow one of the largest Latinx in Tech communities by becoming a sponsor
     </div>
   </div>
   <div class="field">
-    <label class="label">Anything else you'd like to add?</label>
+    <label class="label">¿Algún otro asunto que desea incluir?</label>
     <div class="control">
       <textarea class="textarea" aria-label="Message" spellcheck="true" rows="3" name="message" id="message" placeholder=""></textarea>
     </div>
@@ -74,7 +74,7 @@ Help us grow one of the largest Latinx in Tech communities by becoming a sponsor
   <div data-netlify-recaptcha="true"></div>
   <div class="field mt-sm">
     <div class="control">
-      <button type="submit" class="button is-primary">Submit</button>
+      <button type="submit" class="button is-primary">Enviar</button>
     </div>
   </div>
 </form>

--- a/content/support-us/_index.es.md
+++ b/content/support-us/_index.es.md
@@ -7,7 +7,7 @@ categories:
 
 Ayúdenos a crecer una de las comunidades Latinx en Tech más grandes haciéndose un patrocinador, socio, o voluntario.
 
-> Si esta interesado en convertirse en un patrocinador o socio oficial, por favor complete el formulario y le contestaremos lo más pronto posible. 
+> Si está interesado en convertirse en un patrocinador o socio oficial, por favor complete el formulario y le contestaremos lo más pronto posible. 
 
 <form name="Become a Supporter" method="POST" data-netlify="true">
   <input type="hidden" aria-label="Subject" name="_subject" value="Techqueria - Become a Supporter">
@@ -57,7 +57,7 @@ Ayúdenos a crecer una de las comunidades Latinx en Tech más grandes haciéndos
     </div>
   </div>
   <div class="field">
-    <label class="label">¿Cómo escucho de Techqueria?</label>
+    <label class="label">¿Cómo escuchó de Techqueria?</label>
     <div class="control has-icons-left">
       <input class="input" aria-label="Referral" autocomplete="on" type="text" name="referral" placeholder="Twitter">
       <span class="icon is-left">

--- a/content/support-us/donate-space.es.md
+++ b/content/support-us/donate-space.es.md
@@ -1,27 +1,27 @@
 ---
-title: "Donate space"
-description: "Donating space for Techqueria events provides a great opportunity for our members to get a peek of your company environment while also supporting the growth and advancement of our members."
+title: "Donar espacio"
+description: "Donar espacio para eventos de Techqueria proporciona una oportunidad fantástica para que nuestrso miembros puedan aprender sobre el ambiente de su compañía mientras que también apoya el crecimiento y ascenso de nuestros miembros."
 image: "/assets/img/banners/donate-space.jpg"
 ---
 
-Techqueria events are usually held at different tech companies across the US.
+Eventos de Techqueria típicamente toman lugar en compañías distintas a través de EEUU.
 
-Donating space for Techqueria events provides a great opportunity for our members to get a peek of your company environment while also supporting the growth and advancement of our members.
+Donar espacio para eventos de Techqueria proporciona una oportunidad fantástica para que nuestros miembros puedan aprender sobre el ambiente de su compañía mientras que también apoya el crecimiento y ascenso de nuestros miembros.
 
-The number of attendees varies - from a few to hundreds with most events happening on evenings during the week from 6 to 9 pm.
+La cantidad de asistentes varía - desde algunos pocos asta algunos pocos cientos con la mayoría de los eventos tomando lugar entre 6 a 9 PM durante la semana. 
 
-As a host, you commit to providing the following:
+Como anfitrión, usted se compromete a proveer lo siguiente: 
 
-- catering & space up for our attendees
-- a company representative to initially welcome the group and introduce the company (ideally, they identify as Latinx)
-- (optional) [a shared channel](https://get.slack.help/hc/en-us/articles/115004151203-Create-shared-channels-on-a-workspace-beta-) between Techqueria's Slack Workspace and your company's Slack Workspace
+- servicio de comidas y espacio para nuestros asistentes 
+- un representante (quien idealmente se identifica como Latinx) quien pueda darle una bienvenida al grupo e introducir la compañía 
+- (opcional) [un canal compartido](https://get.slack.help/hc/es/articles/115004151203-Crear-canales-compartidos-en-un-espacio-de-trabajo-beta-) entre el espacio de trabajo Slack de Techqueria y el espacio de trabajo Slack de su compañía. 
 
-> If you're interested in donating space, please fill out the form below and we'll get back to you ASAP.
+> Si está interesado en donar espacio, por favor complete el formulario y le contestaremos lo más pronto posible. 
 
 <form name="Donate Space" method="POST" data-netlify="true">
   <input type="hidden" aria-label="Subject" name="_subject" value="Techqueria - Donate Space">
   <div class="field">
-    <label class="label">Organization*</label>
+    <label class="label">Organización*</label>
     <div class="control has-icons-left">
       <input class="input" aria-label="Organization" autocomplete="on" type="text" name="organization" placeholder="Your organization" required>
       <span class="icon is-left">
@@ -30,7 +30,7 @@ As a host, you commit to providing the following:
     </div>
   </div>
   <div class="field">
-    <label class="label">Name*</label>
+    <label class="label">Nombre*</label>
     <div class="control has-icons-left">
       <input class="input" aria-label="Name" autocomplete="on" type="text" name="name" placeholder="Your name" required>
       <span class="icon is-left">
@@ -39,7 +39,7 @@ As a host, you commit to providing the following:
     </div>
   </div>
   <div class="field">
-    <label class="label">Email*</label>
+    <label class="label">Correo Electrónico*</label>
     <div class="control has-icons-left">
       <input class="input" aria-label="Email" autocomplete="on" type="email" name="email" placeholder="Your email" required>
       <span class="icon is-left">
@@ -48,7 +48,7 @@ As a host, you commit to providing the following:
     </div>
   </div>
   <div class="field">
-    <label class="label">LinkedIn Profile URL*</label>
+    <label class="label">URL de Perfil LinkedIn </label>
     <div class="control has-icons-left">
       <input class="input" aria-label="Organization" autocomplete="on" type="url" name="organization" placeholder="https://www.linkedin.com/in/" required>
       <span class="icon is-left">
@@ -57,7 +57,7 @@ As a host, you commit to providing the following:
     </div>
   </div>
   <div class="field">
-    <label class="label">What's the max number of people you can host (comfortably) for an event?*</label>
+    <label class="label">¿Cuál es la cantidad de personas maxima que puede hospedar (cómodamente) para un evento?*</label>
     <div class="control has-icons-left">
       <input class="input" aria-label="Attendees" autocomplete="on" type="number" name="attendees" placeholder="200" required>
       <span class="icon is-left">
@@ -66,7 +66,7 @@ As a host, you commit to providing the following:
     </div>
   </div>
   <div class="field">
-    <label class="label">Where would you like to host an event?*</label>
+    <label class="label">¿Dónde le gustaría organizar un evento? </label>
     <div class="control has-icons-left">
       <input class="input" aria-label="Location" autocomplete="on" type="text" name="location" placeholder="San Francisco, CA" required>
       <span class="icon is-left">
@@ -75,7 +75,7 @@ As a host, you commit to providing the following:
     </div>
   </div>
   <div class="field">
-    <label class="label">How did you hear about Techqueria?</label>
+    <label class="label">¿Cómo escuchó de Techqueria? </label>
     <div class="control has-icons-left">
       <input class="input" aria-label="Referral" autocomplete="on" type="text" name="referral" placeholder="Twitter">
       <span class="icon is-left">
@@ -84,7 +84,7 @@ As a host, you commit to providing the following:
     </div>
   </div>
   <div class="field">
-    <label class="label">Anything else you'd like to add?</label>
+    <label class="label">¿Algún otro asunto que desea incluir? </label>
     <div class="control">
       <textarea class="textarea" aria-label="Message" spellcheck="true" rows="5" name="message" id="message" placeholder=""></textarea>
     </div>
@@ -92,7 +92,7 @@ As a host, you commit to providing the following:
   <div data-netlify-recaptcha="true"></div>
   <div class="field mt-sm">
     <div class="control">
-      <button type="submit" class="button is-primary">Submit</button>
+      <button type="submit" class="button is-primary">Enviar</button>
     </div>
   </div>
 </form>

--- a/content/support-us/supporters/_index.es.md
+++ b/content/support-us/supporters/_index.es.md
@@ -1,11 +1,11 @@
 ---
-title: Our Supporters
+title: Nuestros partidarios
 description: Sponsors, partners or contributors who have helped us maintain one of the largest Latinx in Tech communities.
 image: "/assets/img/banners/our-supporters.jpg"
 ---
 
-The following companies or individuals have helped with one or more of the following:
+Las siguientes compañías o individuos nos han ayudado con una o mas de las siguientes: 
 
-- hosted our events (in the past or present)
-- donated resources to our community
-- partnered up with us on events
+- alojaron nuestros eventos (en el pasado o presente)
+- donaron recursos a nuestra comunidad
+- se asociaron con nosotros en nuestros eventos

--- a/content/support-us/supporters/braintree.es.md
+++ b/content/support-us/supporters/braintree.es.md
@@ -1,0 +1,6 @@
+---
+title: Braintree
+description: Solución completa para aceptar, procesar, y dividir pagos en su app mobil o en la red
+link: https://www.braintreepayments.com/careers
+image: "/assets/img/sponsors/braintree.png"
+---

--- a/content/support-us/supporters/caremessage.es.md
+++ b/content/support-us/supporters/caremessage.es.md
@@ -1,0 +1,6 @@
+---
+title: Caremessage
+description: Empodera organizaciones de cuidado de salud con tecnologías mobiles para mejorar el alfabetismo de salud y el manejo de auto-salud mientras promoviendo un envío de cuidado más eficiente
+link: https://caremessage.org/careers/
+image: https://assets.themuse.com/uploaded/companies/1391/small_logo.png?v=f0c5a7dc14523dedec049714422af4eab90785459bec993256427620ee42a74a
+---

--- a/content/support-us/supporters/cisco-systems-meraki.es.md
+++ b/content/support-us/supporters/cisco-systems-meraki.es.md
@@ -1,0 +1,6 @@
+---
+title: Cisco Systems/Meraki
+description: Proporciona soluciones para WiFi, encaminamiento, y seguridad controlados por WiFi
+link: https://meraki.cisco.com/jobs
+image: https://meraki.cisco.com/img/cisco-meraki-logo.jpg
+---

--- a/content/support-us/supporters/climate-corporation.es.md
+++ b/content/support-us/supporters/climate-corporation.es.md
@@ -1,0 +1,6 @@
+---
+title: Climate Corporation
+description: Empresa de agricultura digital que examina datos del clima, la tierra, y el campo para ayudar a granjeros determinar potenciales limitantes de rendimiento en sus campos 
+link: https://climate.com/careers
+image: https://images.agriculture.mdpcdn.com/sites/default/files/styles/width_550/public/image/2016/11/22/climate-corporation.jpg
+---

--- a/content/support-us/supporters/devbootcamp.es.md
+++ b/content/support-us/supporters/devbootcamp.es.md
@@ -1,0 +1,6 @@
+---
+title: Dev Bootcamp
+description: Curso de desarrollo de software intensivo en SF
+link: https://en.wikipedia.org/wiki/Dev_Bootcamp
+image: https://edsurge.imgix.net/uploads/post/image/4606/2014-1444858580.jpg?auto=compress%2Cformat&w=2000&h=810&fit=crop
+---

--- a/content/support-us/supporters/digital-ocean.es.md
+++ b/content/support-us/supporters/digital-ocean.es.md
@@ -1,0 +1,6 @@
+---
+title: DigitalOcean
+description: Le proporciona a desarrolladores y negocios una plataforma segura y fácil de usar de computación en la nube para servidores virtuales, almacenamiento de objetos, y más
+link: https://www.digitalocean.com/careers
+image: https://urbankenyans.com/wp-content/uploads/2018/01/digitalocean-logo.jpg
+---

--- a/content/support-us/supporters/dropbox.es.md
+++ b/content/support-us/supporters/dropbox.es.md
@@ -1,0 +1,6 @@
+---
+title: Dropbox
+description: Servicio de alojamiento de archivos que ofrece almacenamiento en la nube, sincronización de archivos, nube personal, y software para el cliente
+link: https://www.dropbox.com/jobs?&gh_src=x36ci4
+image: https://aem.dropbox.com/cms/content/dam/dropbox/www/en-us/branding/dropbox-logo@2x.jpg
+---

--- a/content/support-us/supporters/ecosystem-sf.es.md
+++ b/content/support-us/supporters/ecosystem-sf.es.md
@@ -1,0 +1,6 @@
+---
+title: Ecosystem SF
+description: Espacio de trabajo cooperativo en SF
+link: https://eco-systm.com/
+image: https://lifeyostaticfiles.s3.amazonaws.com/static/uploads/2x/xsNRnb2TwCwwrpm79cTo_main%20space%20a.jpg
+---

--- a/content/support-us/supporters/github-universe.es.md
+++ b/content/support-us/supporters/github-universe.es.md
@@ -1,0 +1,8 @@
+---
+title: GitHub Universe
+description: “Con menos de un mes para GitHub Universe, nos emociona anunciar nuestros Socios Comunitarios de 2017!”
+link: https://githubuniverse.com/2017/after-party/
+image: https://pbs.twimg.com/media/DppRwaLWkAAdYOR.jpg
+---
+
+https://githubuniverse.com/2017/viewing-parties/

--- a/content/support-us/supporters/github.es.md
+++ b/content/support-us/supporters/github.es.md
@@ -1,0 +1,6 @@
+---
+title: GitHub
+description: Armando las herramientas que facilitan la colaboración y escritura de software para todos 
+link: https://github.com/about/careers
+image: https://cdn-images-1.medium.com/max/2000/1*CmjmgiI3Sr6oByNZ81pkhQ.jpeg
+---

--- a/content/support-us/supporters/google.es.md
+++ b/content/support-us/supporters/google.es.md
@@ -1,0 +1,6 @@
+---
+title: Google (Venice)
+description: Asistir en la búsqueda de la información mundial, incluyendo páginas de web, imagines, videos, y más
+link: https://www.braintreepayments.com/careers
+image: https://storage.googleapis.com/gd-wagtail-prod-assets/original_images/evolving_google_identity_share.jpg
+---

--- a/content/support-us/supporters/hackbright-academy.es.md
+++ b/content/support-us/supporters/hackbright-academy.es.md
@@ -1,0 +1,6 @@
+---
+title: Hackbright Academy
+description: Escuela destacada de ingeniería de software para mujeres. Fundada en San Francisco en 2012
+link: https://hackbrightacademy.com/
+image: https://innov8tiv.com/wp-content/uploads/2018/06/hackbright-academy-1-750x400.jpg
+---

--- a/content/support-us/supporters/huge.es.md
+++ b/content/support-us/supporters/huge.es.md
@@ -1,0 +1,6 @@
+---
+title: Huge
+description: Equipos pequeños trabajando en retas grandes en colaboración honesta con nuestros clientes
+link: https://www.hugeinc.com/contactus/oakland
+image: https://www.agencyloft.com/wp-content/uploads/2017/01/commonwealth.jpg.png
+---

--- a/content/support-us/supporters/i-am-an-immigrant.es.md
+++ b/content/support-us/supporters/i-am-an-immigrant.es.md
@@ -1,0 +1,6 @@
+---
+title: "I Am An Immigrant"
+description: “La diversidad—estimulada en gran parte por inmigrantes—nos hace más fuertes y conectados como una nación”
+link: https://www.iamanimmigrant.com/partners/
+image: https://2t9qt14cl5rc3ei81o3goyix-wpengine.netdna-ssl.com/wp-content/uploads/2017/04/iaai-metaimage-1.jpg
+---

--- a/content/support-us/supporters/informedk12.es.md
+++ b/content/support-us/supporters/informedk12.es.md
@@ -1,0 +1,6 @@
+---
+title: InformedK12
+description: Solución de flujo de trabajo automatizado fácil de usar que ayuda a los administradores de distritos escolares digitaliza formularios, automatizar procesos, y rastrear aprobaciones
+link: https://www.informedk12.com/careers
+image: "/assets/img/sponsors/informedk12.png"
+---

--- a/content/support-us/supporters/kapor-center.es.md
+++ b/content/support-us/supporters/kapor-center.es.md
@@ -1,0 +1,6 @@
+---
+title: Kapor Center
+description: Haciendo el ecosistema tech y el emprendimiento más diverso, inclusivo, e impactante
+link: https://www.kaporcenter.org/
+image: "/assets/img/sponsors/kapor-center.png"
+---

--- a/content/support-us/supporters/lending-club.es.md
+++ b/content/support-us/supporters/lending-club.es.md
@@ -1,0 +1,6 @@
+---
+title: LendingClub
+description: Empresa de prestamos peer to peer en EEUU
+link: https://chj.tbe.taleo.net/chj06/ats/careers/jobSearch.jsp?org=LNDC&cws=1
+image: https://www.retirebeforedad.com/wp-content/uploads/2017/06/Lending-Club-logo.jpg
+---

--- a/content/support-us/supporters/lumosity.es.md
+++ b/content/support-us/supporters/lumosity.es.md
@@ -1,0 +1,6 @@
+---
+title: Lumosity
+description: Programa en línea consistiendo de juegos pretendiendo mejorar la memoria, atención, flexibilidad, velocidad de procesamiento, y la resolución de problemas
+link: https://www.lumosity.com/jobs
+image: https://i.ytimg.com/vi/l1xNcOEqTRw/maxresdefault.jpg
+---

--- a/content/support-us/supporters/mixpanel.es.md
+++ b/content/support-us/supporters/mixpanel.es.md
@@ -1,0 +1,6 @@
+---
+title: Mixpanel
+description: Analítica de comportamiento de usuarios para productos, mercadotecnia, y equipos de datos
+link: https://mixpanel.com/jobs/
+image: "/assets/img/sponsors/mixpanel.png"
+---

--- a/content/support-us/supporters/nextspace-berkeley.md
+++ b/content/support-us/supporters/nextspace-berkeley.md
@@ -1,6 +1,6 @@
 ---
 title: NextSpace Berkeley
-description: Co-working space in Berkeley
+description: Espacio de trabajo cooperativo en Berkeley
 link: https://nextspace.us
 image: https://d22buumxx9ry87.cloudfront.net/uploads/locations/60/photoGrid/nextspace-berkeley-3.jpg?mtime=20160411101709
 ---

--- a/content/support-us/supporters/spotify.es.md
+++ b/content/support-us/supporters/spotify.es.md
@@ -1,0 +1,6 @@
+---
+title: Spotify
+description: Servicio digital de música que te da acceso a millones de canciones
+link: https://www.spotifyjobs.com/
+image: "/assets/img/sponsors/spotify.png"
+---

--- a/content/support-us/supporters/stripe.es.md
+++ b/content/support-us/supporters/stripe.es.md
@@ -1,0 +1,6 @@
+---
+title: Stripe
+description: Infraestructura universal de pagos del internet
+link: https://stripe.com/jobs
+image: https://lawyerist-khcnq28r8rte6wv.stackpathdns.com/wp-content/uploads/2017/06/Stripe-logo.png
+---

--- a/content/support-us/supporters/tech-jobs-tour.es.md
+++ b/content/support-us/supporters/tech-jobs-tour.es.md
@@ -1,0 +1,10 @@
+---
+title: "Tech Jobs Tour"
+description: “Éste tour reunirá talento diverso y no-tradicional con empresas que más necesitan sus habilidades.” 
+link: https://techjobstour.com/tour-cities/chicago2018/
+image: https://techjobstour.com/wp-content/uploads/2017/05/sfphoto.png
+---
+
+This tour will bring together diverse and non-traditional talent with companies who need their skills the most.
+
+Right now America has over 500,000 open tech jobs – by 2020 this number will grow to over 1 million. At the time same time, over 60% of all new coders, engineers and data scientists are emerging from bootcamps and industry-current vocational schools.

--- a/content/support-us/supporters/twilio.es.md
+++ b/content/support-us/supporters/twilio.es.md
@@ -1,0 +1,6 @@
+---
+title: Twilio
+description: Plataforma de comunicaciones en la nube para construir aplicaciones de SMS, Voz, y Mensajería sobre un API construido para la escala global
+link: https://www.twilio.com/company/jobs
+image: https://cdn0.tnwcdn.com/wp-content/blogs.dir/1/files/2015/04/twilio-730x365.jpg
+---

--- a/content/support-us/supporters/uber.es.md
+++ b/content/support-us/supporters/uber.es.md
@@ -1,0 +1,6 @@
+---
+title: Uber
+description: Lleve sus ideas al proximo nivel y construya algo que la gente usa todos los días
+link: https://www.uber.com/careers/
+image: https://cyprianfrancis.com/wp-content/uploads/2017/10/uber_multiple_places.png
+---

--- a/content/support-us/supporters/udacity.es.md
+++ b/content/support-us/supporters/udacity.es.md
@@ -1,0 +1,6 @@
+---
+title: Udacity
+description: Empoderando a estudiantes no solamente para avanzar su educación, si no para obtener su trabajo soñado en tecnología a través de una educación relevante del siglo 21
+link: https://www.udacity.com/jobs
+image: https://i.imgur.com/h1tSGc4.jpg
+---

--- a/content/support-us/supporters/walmart.es.md
+++ b/content/support-us/supporters/walmart.es.md
@@ -1,0 +1,6 @@
+---
+title: Walmart
+description: Corporación americana multinacional de ventas que opera una cadena de hipermercados, grandes almacenes de descuento, y tiendas de comestibles
+link: https://careers.walmart.com/
+image: https://earlymoves.files.wordpress.com/2016/09/walmart.jpg
+---

--- a/content/support-us/supporters/yammer.es.md
+++ b/content/support-us/supporters/yammer.es.md
@@ -1,0 +1,6 @@
+---
+title: Yammer
+description: Impulsados a ayudar a empresas en hacerse más abiertas y en facilitando el compartimiento de ideas y experiencias entre colegas
+link: https://careers.microsoft.com/yammer
+image: https://i.imgur.com/vccI1qs.png
+---

--- a/content/support-us/volunteer.es.md
+++ b/content/support-us/volunteer.es.md
@@ -1,19 +1,19 @@
 ---
-title: "Become a Volunteer"
-description: "If you are interested in supporting Techqueria as an individual, one great way to help out is by volunteering your time."
-image: "/assets/img/banners/become-a-volunteer.jpg"
+title: "Hagase Voluntario"
+description: ""
+image: "Si está interesado en apoyar a Techueria usted mismo, ofreciendo su tiempo como voluntario es una manera fantástica de ayudar."
 ---
 
-If you are interested in supporting Techqueria as an individual, one great way to help out is by volunteering your time.
+Si está interesado en apoyar a Techueria usted mismo, ofreciendo su tiempo como voluntario es una manera fantástica de ayudar.
 
-Fill out the form below and we'll reach out via Slack with more details on you can help support our mission.
+Complete el formulario y le contactaremos a través vez de Slack con más detalles sobre cómo puede usted ayudar nuestra misión. 
 
-> Before filling out the form below, please [make sure you have already joined our Slack community](/communities/slack/) as we will be reaching out through there.
+> Antes de llenar el formulario, por favor [asegurase que ya es parte de nuestra comunidad Slack](/communities/slack) ya que le contactaremos a través de Slack.
 
 <form name="Volunteer" method="POST" data-netlify="true">
   <input type="hidden" aria-label="Subject" name="_subject" value="Techqueria - Volunteer">
   <div class="field">
-    <label class="label">Name*</label>
+    <label class="label">Nombre*</label>
     <div class="control has-icons-left">
       <input class="input" aria-label="Name" autocomplete="on" type="text" name="name" placeholder="Your name" required>
       <span class="icon is-left">
@@ -22,7 +22,7 @@ Fill out the form below and we'll reach out via Slack with more details on you c
     </div>
   </div>
   <div class="field">
-    <label class="label">Slack <a href="https://get.slack.help/hc/en-us/articles/216360827-Change-your-display-name" target="_blank" rel="noopener">Display Name</a>*</label>
+    <label class="label">Slack <a href="https://get.slack.help/hc/en-us/articles/216360827-Change-your-display-name" target="_blank" rel="noopener">Nombre de Slack</a>*</label>
     <div class="control has-icons-left">
       <input class="input" aria-label="Slack Handle" autocomplete="on" type="text" name="slack" placeholder="@" required>
       <span class="icon is-left">
@@ -31,7 +31,7 @@ Fill out the form below and we'll reach out via Slack with more details on you c
     </div>
   </div>
   <div class="field">
-    <label class="label">LinkedIn Profile URL*</label>
+    <label class="label">URL de Perfil LinkedIn </label>
     <div class="control has-icons-left">
       <input class="input" aria-label="Organization" autocomplete="on" type="url" name="organization" placeholder="https://www.linkedin.com/in/" required>
       <span class="icon is-left">
@@ -40,7 +40,7 @@ Fill out the form below and we'll reach out via Slack with more details on you c
     </div>
   </div>
   <div class="field">
-    <label class="label">What chapter are you interested in volunteering for?*</label>
+    <label class="label">Con cuál sede local está interesado en hacerse voluntario?*</label>
     <div class="control has-icons-left">
       <input class="input" aria-label="Location" autocomplete="on" type="text" name="location" placeholder="San Francisco, CA" required>
       <span class="icon is-left">
@@ -49,7 +49,7 @@ Fill out the form below and we'll reach out via Slack with more details on you c
     </div>
   </div>
   <div class="field">
-    <label class="label">How would you like to volunteer?*</label>
+    <label class="label">De qué manera le gustaría ser voluntario?*</label>
     <div class="control">
       <textarea class="textarea" aria-label="Message" spellcheck="true" rows="5" name="message" id="message" placeholder="Planning events, social media, open source, etc." required></textarea>
     </div>
@@ -57,7 +57,7 @@ Fill out the form below and we'll reach out via Slack with more details on you c
   <div data-netlify-recaptcha="true"></div>
   <div class="field mt-sm">
     <div class="control">
-      <button type="submit" class="button is-primary">Submit</button>
+      <button type="submit" class="button is-primary">Enviar</button>
     </div>
   </div>
 </form>


### PR DESCRIPTION
This PR translates the `Support Us` pages (including the Supporters cards) on the Techqueria website. As noted in #236, `/es/donate-space/`, `/es/volunteer/`, and `/es/supporters/` hit a 404.

Although I translated the card as it was, the GitHub Universe card is out of date. It reads: "With GitHub Universe one month away we are excited to announce our 2017 Community Partners!". 

---

<!-- Thank you for contributing to Techqueria, it is much appreciated! 😊 -->

<!-- Before creating a PR, make sure to verify the following. -->

> ✅️ By submitting this PR, I have verified the following

- [x] Checked to [see if a similar PR has already been opened](https://github.com/techqueria/website/pulls) 🤔️
- [x] Reviewed the [contributing guidelines](https://github.com/techqueria/website/blob/master/.github/CONTRIBUTING.md) 🔍️
- [x] Added my name to the bottom of the list under the **Contributors** section in the [README.md](https://github.com/techqueria/website/blob/master/README.md) with a link to my personal website or GitHub profile 👥️ (Optional)
