### PR TITLE
Unified Social Button Design #402

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -279,7 +279,7 @@ disqusShortname                      = "techqueria"
 [[menu.social]]
     name                             = "LinkedIn"
     url                              = "https://www.linkedin.com/company/techqueria/"
-    identifier                       = "fab fa-lg fa-linkedin"
+    identifier                       = "fab fa-lg fa-linkedin-in"
 [[menu.social]]
     name                             = "Twitter"
     url                              = "https://twitter.com/Techqueria"


### PR DESCRIPTION
Resolves part of #402 by using the `linkedin-in` [font awesome icon](https://fontawesome.com/icons/linkedin-in?style=brands) as opposed to `linkedin` [font awesome icon](https://fontawesome.com/icons/linkedin?style=brands). Now both icons will not have any background color, no round edges, etc. 



---

<!-- Thank you for contributing to Techqueria, it is much appreciated! 😊 -->

<!-- Before creating a PR, make sure to verify the following. -->

> ✅️ By submitting this PR, I have verified the following

- [ ] Checked to [see if a similar PR has already been opened](https://github.com/techqueria/website/pulls) 🤔️
- [ ] Reviewed the [contributing guidelines](https://github.com/techqueria/website/blob/master/.github/CONTRIBUTING.md) 🔍️
- [ ] Added my name to the bottom of the list under the **Contributors** section in the [README.md](https://github.com/techqueria/website/blob/master/README.md) with a link to my personal website or GitHub profile 👥️ (Optional)
