### PR TITLE
Added new Patreon Supporter Charlie Rivas

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ More details can be found at this project's [code of conduct](.github/CODE_OF_CO
 - [Pablo Carbajal](https://www.futuristics.net/)
 - [Esteban Uribe](https://www.github.com/estebanuribe)
 - [Daniel Andrade](https://github.com/daniel9a)
+- [Edgar Lopez](https://www.github.com/edgineer)
 
 ### Thank you to **all our backers**! ([Become a backer](https://opencollective.com/techqueria#backer))
 

--- a/layouts/_default/page-team.html
+++ b/layouts/_default/page-team.html
@@ -55,6 +55,7 @@
       {{ if (.Site.GetPage "/team/giovanni-bryden") }}{{ partial "content/child.html" (.Site.GetPage "/team/giovanni-bryden") }}{{ end }}
       {{ if (.Site.GetPage "/team/krystal-flores") }}{{ partial "content/child.html" (.Site.GetPage "/team/krystal-flores") }}{{ end }}
       {{ if (.Site.GetPage "/team/liliana-a-monge") }}{{ partial "content/child.html" (.Site.GetPage "/team/liliana-a-monge") }}{{ end }}
+      {{ if (.Site.GetPage "/team/charlie-rivas") }}{{ partial "content/child.html" (.Site.GetPage "/team/charlie-rivas") }}{{ end }}
     </div>
     <!-- Past Team Members -->
     <div class="content mt-2">


### PR DESCRIPTION
Adds new Patreon Supporter Charlie Rivas on /team page.
Issue #514 can manage moving Charlie Rivas and all other Patreon Supporters to the support page.
- Fixes #513
---

<!-- Thank you for contributing to Techqueria, it is much appreciated! 😊 -->

<!-- Before creating a PR, make sure to verify the following. -->

> ✅️ By submitting this PR, I have verified the following

- [x] Checked to [see if a similar PR has already been opened](https://github.com/techqueria/website/pulls) 🤔️
- [x] Reviewed the [contributing guidelines](https://github.com/techqueria/website/blob/master/.github/CONTRIBUTING.md) 🔍️
- [x] Added my name to the bottom of the list under the **Contributors** section in the [README.md](https://github.com/techqueria/website/blob/master/README.md) with a link to my personal website or GitHub profile 👥️ (Optional)
